### PR TITLE
update regex pattern for GovCloud ARN partition

### DIFF
--- a/awsqs-kubernetes-helm.json
+++ b/awsqs-kubernetes-helm.json
@@ -5,7 +5,7 @@
     "definitions": {
         "Arn": {
             "type": "string",
-            "pattern": "^arn:aws(-(cn|gov))?:[a-z-]+:(([a-z]+-)+[0-9])?:([0-9]{12})?:[^.]+$"
+            "pattern": "^arn:aws(-(cn|us-gov))?:[a-z-]+:(([a-z]+-)+[0-9])?:([0-9]{12})?:[^.]+$"
         }
     },
     "properties": {


### PR DESCRIPTION
Simple update that corrects an issue for GovCloud users. 
Limiting the pattern to 'gov' instead of 'us-gov' will cause a pattern mismatch and cause a stack to fail in GovCloud regions.

*Issue #, if available:*
N/A
*Description of changes:*
Updated the regex pattern from 'gov to 'us-gov' which will now correctly match up with the GovCloud partition of the ARN.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
