### PR TITLE
Set executionrole for the created resource

### DIFF
--- a/deploy.template.yaml
+++ b/deploy.template.yaml
@@ -91,6 +91,7 @@ Resources:
         LogGroupName: awsqs-kubernetes-helm-logs
         LogRoleArn: !GetAtt LogDeliveryRole.Arn
       SchemaHandlerPackage: !Ref HandlerPackage
+      ExecutionRoleArn: !GetAtt ExecutionRole.Arn
   ResourceDefaultVersion:
     Type: AWS::CloudFormation::ResourceDefaultVersion
     Properties:


### PR DESCRIPTION
﻿Commit https://github.com/aws-quickstart/quickstart-helm-resource-provider/commit/36bb0ef3e196d5ddc33c1ccefe273b0f807b387b broke my existing cloudformation template with error laid out at
https://github.com/aws-quickstart/quickstart-helm-resource-provider/issues/19#issuecomment-820253918.

This fixes the error.

cc @arunbhagyanath