### PR TITLE
removed GOPROXY from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ COPY . /build
 
 WORKDIR /build
 
-RUN GOPROXY=direct go mod download
+RUN go mod download
 
-RUN GOPROXY=direct make -f Makefile.package package
+RUN make -f Makefile.package package
 
 CMD mkdir -p /output/ && mv /build/awsqs-kubernetes-helm.zip /output/


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-quickstart/quickstart-amazon-eks/issues/367


*Description of changes:*

Executing `build/lambda_package.sh` consistently fails

```bash
 => CACHED [4/7] COPY . /build                                                                                                                                                                                                                                                                                                                                                                                                                                                                       0.0s
 => CACHED [5/7] WORKDIR /build                                                                                                                                                                                                                                                                                                                                                                                                                                                                      0.0s
 => ERROR [6/7] RUN GOPROXY=direct go mod download                                                                                                                                                                                                                                                                                                                                                                                                                                                   2.3s
------
 > [6/7] RUN GOPROXY=direct go mod download:
#10 2.228 go: github.com/aws-cloudformation/cloudformation-cli-go-plugin@v1.0.3: reading github.com/aws-cloudformation/cloudformation-cli-go-plugin/go.mod at revision v1.0.3: unknown revision v1.0.3
------
failed to solve with frontend dockerfile.v0: failed to build LLB: executor failed running [/bin/sh -c GOPROXY=direct go mod download]: runc did not terminate sucessfully
```

`GOPROXY=direct` was the culprit. I removed them and was able to successfully build afterwards. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
